### PR TITLE
Fix pnpm lockfile compatibility in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 10
           
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 10
           
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- use pnpm v10 in GitHub workflows so `--frozen-lockfile` works

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686b0b5f41d08328829e19d7bd1a6522