### PR TITLE
Fix typecheck in monorepo

### DIFF
--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -7,7 +7,7 @@
     "dev": "vite build --watch",
     "build": "vite build",
     "test": "vitest --passWithNoTests",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc -b"
   },
   "license": "MIT",
   "dependencies": {
@@ -19,6 +19,8 @@
     "@vitejs/plugin-react": "^4.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
     "sharp": "^0.34.2",
     "typescript": "^5.3.3",
     "vite": "^5.0.0",

--- a/packages/chrome-extension/src/background/index.ts
+++ b/packages/chrome-extension/src/background/index.ts
@@ -1,4 +1,4 @@
-import { ChromeMessage, LogRecord, SERVER_URL, PATHS, BATCH_INTERVAL_MS, encodeBase64 } from '@vibelogger/shared';
+import { ChromeMessage, LogRecord, SERVER_URL, PATHS, BATCH_INTERVAL_MS, encodeBase64, AllowedSite } from '@vibelogger/shared';
 
 interface LogBatch {
   name: string;

--- a/packages/chrome-extension/src/popup/main.tsx
+++ b/packages/chrome-extension/src/popup/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { App } from './App';
+import { App } from './App.js';
 import './style.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/packages/chrome-extension/tsconfig.json
+++ b/packages/chrome-extension/tsconfig.json
@@ -6,7 +6,7 @@
     "composite": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
-    "types": ["chrome"]
+    "types": ["chrome", "react", "react-dom"]
   },
   "include": ["src/**/*"],
   "references": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,7 +30,7 @@
     "build": "tsc -b && chmod +x dist/cli.js",
     "dev": "tsx src/cli.ts",
     "test": "vitest --passWithNoTests",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b",
     "prepublishOnly": "pnpm build"
   },
   "publishConfig": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx watch src/server.ts",
     "start": "node dist/server.js",
     "test": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc -b"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,7 +9,7 @@
     "build": "tsc -b",
     "dev": "tsc -b -w",
     "test": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc -b"
   },
   "license": "MIT",
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,12 @@ importers:
       '@types/node':
         specifier: ^20.11.0
         version: 20.19.4
+      '@types/react':
+        specifier: ^18.2.0
+        version: 18.3.23
+      '@types/react-dom':
+        specifier: ^18.2.0
+        version: 18.3.7(@types/react@18.3.23)
       '@vitejs/plugin-react':
         specifier: ^4.2.0
         version: 4.6.0(vite@5.4.19(@types/node@20.19.4))
@@ -936,6 +942,17 @@ packages:
   '@types/node@20.19.4':
     resolution: {integrity: sha512-OP+We5WV8Xnbuvw0zC2m4qfB/BJvjyCwtNjhHdJxV1639SGSKrLmJkc3fMnp2Qy8nJyHp8RO6umxELN/dS1/EA==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.23':
+    resolution: {integrity: sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -1243,6 +1260,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -3034,6 +3054,17 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.23)':
+    dependencies:
+      '@types/react': 18.3.23
+
+  '@types/react@18.3.23':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.1.3
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 20.19.4
@@ -3411,6 +3442,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  csstype@3.1.3: {}
 
   data-uri-to-buffer@4.0.1: {}
 


### PR DESCRIPTION
## Summary
- run `tsc -b` for all packages so TypeScript respects project references
- add React type dependencies to chrome extension
- enable react typings in extension tsconfig
- fix imports after enabling NodeNext resolution

## Testing
- `pnpm typecheck`
- `CI=1 pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686b36099f0c8328bb42bc27a3d5cc95